### PR TITLE
prerequisites: add a script for easy installation.

### DIFF
--- a/prerequisites.sh
+++ b/prerequisites.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# For Ubuntu 18.04
+apt install -y git tmux flex bison gcc-arm-linux-gnueabi qemu qemu-utils qemu-system-arm gdb-multiarch cgdb


### PR DESCRIPTION
This 'prerequisites.sh' script is tested on Ubuntu 18.04.2 LTS.
It would support other linux distributions.

Fixed: #3